### PR TITLE
adding class name to rails_admin file generated and remove useless translate to model_name in pt-BR attributes block 

### DIFF
--- a/lib/admin_model/version.rb
+++ b/lib/admin_model/version.rb
@@ -1,3 +1,3 @@
 module AdminModels
-  VERSION = '0.1.2'
+  VERSION = '0.1.3'
 end

--- a/lib/generators/admin_model/admin_model_generator.rb
+++ b/lib/generators/admin_model/admin_model_generator.rb
@@ -8,6 +8,7 @@ class AdminModelGenerator < Rails::Generators::NamedBase
   end
 
   def crate_rails_admin_concern
+    @class_name = class_name
     @fields_list = ''
     @attributes.each do |attribute|
       @fields_list << "\n        field :#{attribute.name}"
@@ -29,7 +30,7 @@ class AdminModelGenerator < Rails::Generators::NamedBase
     end
     model_attriutes = ''
     @attributes.each do |attribute|
-      model_attriutes << "\n        #{attribute.name}: please fill me"
+      model_attriutes << "\n        #{attribute.name}:"
     end
     inject_into_file 'config/locales/pt-BR.yml', after: "\n    attributes:\n" do
       <<-YML

--- a/lib/generators/admin_model/admin_model_generator.rb
+++ b/lib/generators/admin_model/admin_model_generator.rb
@@ -30,11 +30,11 @@ class AdminModelGenerator < Rails::Generators::NamedBase
     end
     model_attriutes = ''
     @attributes.each do |attribute|
-      model_attriutes << "\n        #{attribute.name}:"
+      model_attriutes << "\n        #{attribute.name}: please fill me"
     end
     inject_into_file 'config/locales/pt-BR.yml', after: "\n    attributes:\n" do
       <<-YML
-      #{name}: please fill me#{model_attriutes}
+      #{name}:#{model_attriutes}
       YML
     end
   end


### PR DESCRIPTION
# What was done?
  - Pass the `model_name` value to `@class_name` variable;
  - Removed the `please fill me` from the `model_name` in the attribute block, because `rails admin gem` gives an error when has some text there.
  - Updated the gem version to 0.1.3.

# Before and After
 - Before these changes, the rails admin file was created without `model_name` something like this:
```
      module RailsAdmin::
      extend ActiveSupport::Concern
     
      [code ...]
```
  - Now, the file is created with the `model_name`, like this:
```
      module RailsAdmin::ModelName
      extend ActiveSupport::Concern
     
      [code ...]
```
  - Before these changes, the text that was inserted in the `pt-BR.yml` file in the `attributes` blocks looked like this:
```
     attributes:
      model_name: please fill me
        attribute: please fill me
        attribute: please fill me
```
  - And now it looks like this:
```
     attributes:
      mode_namel: 
        attribute: please fill me
        attribute: please fill me
```